### PR TITLE
Optimize listen page mp3 loading

### DIFF
--- a/listen.html
+++ b/listen.html
@@ -230,7 +230,7 @@
                     
                     <div class="audio-section">
                         <div class="audio-title">Desire Lines</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/Desire-Lines.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>
@@ -238,7 +238,7 @@
 
                     <div class="audio-section">
                         <div class="audio-title">The Goose and Common</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/The-Goose-and-Common.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>
@@ -246,7 +246,7 @@
 
                     <div class="audio-section">
                         <div class="audio-title">Dover Beach</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/Dover-Beach.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>
@@ -254,7 +254,7 @@
 
                     <div class="audio-section">
                         <div class="audio-title">Dover Beach – a cappella</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/Dover-Beach-a-cappella.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>
@@ -265,7 +265,7 @@
 
                     <div class="audio-section">
                         <div class="audio-title">Down in the River to Pray</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/Down-in-the-River-to-Pray.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>
@@ -273,7 +273,7 @@
 
                     <div class="audio-section">
                         <div class="audio-title">Cradle Spell of Dunvegan</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/Cradle-Spell-of-Dunvegan.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>
@@ -281,7 +281,7 @@
 
                     <div class="audio-section">
                         <div class="audio-title">The Birch Tree</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/The-Birch-Tree.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>
@@ -292,7 +292,7 @@
 
                     <div class="audio-section">
                         <div class="audio-title">Strays of St Ives</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/Strays-of-St-Ives.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>
@@ -300,7 +300,7 @@
 
                     <div class="audio-section">
                         <div class="audio-title">Lyonnesse</div>
-                        <audio controls>
+                        <audio controls preload="none">
                             <source src="mp3s/Lyonnesse.mp3" type="audio/mpeg">
                             Your browser does not support the audio element.
                         </audio>


### PR DESCRIPTION
Improve "Listen" page load performance by adding `preload="none"` to all audio elements.

---

[Open in Web](https://www.cursor.com/agents?id=bc-b6fdbe3b-4682-4e47-a567-8221a7f0e899) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b6fdbe3b-4682-4e47-a567-8221a7f0e899)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)